### PR TITLE
Fix failover trigger expression

### DIFF
--- a/Template_Cisco_ASA_1.1.3.xml
+++ b/Template_Cisco_ASA_1.1.3.xml
@@ -142,7 +142,7 @@ TODO (maybe): Interface statistic and more triggers.</description>
                     </applications>
                     <triggers>
                         <trigger>
-                            <expression>{change()}=0</expression>
+                            <expression>{change()}=1</expression>
                             <recovery_mode>NONE</recovery_mode>
                             <name>{HOST.NAME} Cisco ASA Failover triggered</name>
                             <priority>HIGH</priority>

--- a/Template_Cisco_ASA_1.1.xml
+++ b/Template_Cisco_ASA_1.1.xml
@@ -110,7 +110,7 @@ TODO (maybe): Interface statistic and more triggers.</description>
                     </applications>
                     <triggers>
                         <trigger>
-                            <expression>{change()}=0</expression>
+                            <expression>{change()}=1</expression>
                             <recovery_mode>NONE</recovery_mode>
                             <name>{HOST.NAME} Cisco ASA Failover triggered</name>
                             <priority>HIGH</priority>


### PR DESCRIPTION
As of documentation
https://www.zabbix.com/documentation/5.0/manual/appendix/triggers/functions
change() function result is 0 if strings are equal and 1 if they are not.